### PR TITLE
disable setting style cookie if style cookies are disabled (#1233)

### DIFF
--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1625,7 +1625,10 @@ void ChangeClientStyle(int client, int style, bool manual)
 	char sStyle[4];
 	IntToString(style, sStyle, 4);
 
-	SetClientCookie(client, gH_StyleCookie, sStyle);
+	if(gB_StyleCookies)
+	{
+		SetClientCookie(client, gH_StyleCookie, sStyle);
+	}
 }
 
 public void Player_Jump(Event event, const char[] name, bool dontBroadcast)


### PR DESCRIPTION
* shavit-core.sp - disable style cookie is style cookies are disabled

Edge case causing this change, but if style cookies are disabled on a server, no reason to save it.