### PR TITLE
Startzone speed limit flexibility (#1219)

### DIFF
--- a/addons/sourcemod/configs/shavit-styles.cfg
+++ b/addons/sourcemod/configs/shavit-styles.cfg
@@ -35,6 +35,7 @@
 		// Physics
 		"airaccelerate"		"1000.0" // sv_airaccelerate value for the style.
 		"runspeed"			"260.00" // Running speed. Requires DHooks, shavit-misc and shavit_misc_staticprestrafe set to 1.
+		"maxprestrafe"      "0.0" // The max prestrafe that still allows your timer to start/restart. You generally do *not* need or want to change this unless for surf things (combined with style-setting "prespeed_type" "6" or cvar "shavit_misc_prespeed 6"). Default is 0.0 (disabled).
 		"gravity"			"1.0" // Gravity setting, 1.0 for default. Standard for low gravity styles is 0.6.
 		"speed"				"1.0" // Speed multiplier, 1.0 for default. Standard for slowmo styles is 0.5. This a multiplier for m_flLaggedMovementValue.
 		"timescale"			"1.0" // Timing will scale with this setting. This is a multiplier for m_flLaggedMovementValue but also affects the timer increase speed.

--- a/addons/sourcemod/scripting/include/shavit/style-settings.sp
+++ b/addons/sourcemod/scripting/include/shavit/style-settings.sp
@@ -164,6 +164,7 @@ public SMCResult OnStyleEnterSection(SMCParser smc, const char[] name, bool opt_
 
 	SetStyleSettingFloat(gI_CurrentParserIndex, "airaccelerate", 1000.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "runspeed", 260.00);
+	SetStyleSettingFloat(gI_CurrentParserIndex, "maxprestrafe", 0.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "gravity", 1.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "speed", 1.0);
 	SetStyleSettingInt  (gI_CurrentParserIndex, "halftime", 0);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -172,6 +172,7 @@ char gS_Verification[MAXPLAYERS+1][8];
 bool gB_CookiesRetrieved[MAXPLAYERS+1];
 float gF_ZoneAiraccelerate[MAXPLAYERS+1];
 float gF_ZoneSpeedLimit[MAXPLAYERS+1];
+float gF_ZoneStartSpeedLimit[MAXPLAYERS+1];
 int gI_LastPrintedSteamID[MAXPLAYERS+1];
 
 // kz support
@@ -2521,7 +2522,23 @@ bool CanStartTimer(int client, int track, bool skipGroundCheck)
 	if (curVel <= 50.0)
 		return true;
 
-	float prestrafe = StyleMaxPrestrafe(style);
+	float cfgMax = GetStyleSettingFloat(style, "maxprestrafe");
+	float zoneMax = gF_ZoneStartSpeedLimit[client];
+	float prestrafe;
+
+	if (zoneMax > 0.0)
+	{
+		prestrafe = zoneMax;
+	}
+	else if (cfgMax > 0.0)
+	{
+		prestrafe = cfgMax;
+	}
+	else
+	{
+		prestrafe = StyleMaxPrestrafe(style);
+	}
+
 	if (curVel > prestrafe)
 		return false;
 
@@ -2909,7 +2926,11 @@ void SQL_DBConnect()
 
 public void Shavit_OnEnterZone(int client, int type, int track, int id, int entity, int data)
 {
-	if (type == Zone_Airaccelerate && track == gA_Timers[client].iTimerTrack)
+	if (type == Zone_Start && track == gA_Timers[client].iTimerTrack)
+	{
+		gF_ZoneStartSpeedLimit[client] = float(data);
+	}
+	else if (type == Zone_Airaccelerate && track == gA_Timers[client].iTimerTrack)
 	{
 		gF_ZoneAiraccelerate[client] = float(data);
 	}
@@ -2931,7 +2952,7 @@ public void Shavit_OnLeaveZone(int client, int type, int track, int id, int enti
 	//       Probably so very niche that it doesn't matter.
 	if (track != gA_Timers[client].iTimerTrack)
 		return;
-	if (type != Zone_Airaccelerate && type != Zone_CustomSpeedLimit && type != Zone_Autobhop)
+	if (type != Zone_Airaccelerate && type != Zone_CustomSpeedLimit && type != Zone_Autobhop && type != Zone_Start)
 		return;
 
 	UpdateStyleSettings(client);

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -74,6 +74,8 @@ Function gH_AfterWarningMenu[MAXPLAYERS+1];
 int gI_LastWeaponTick[MAXPLAYERS+1];
 int gI_LastNoclipTick[MAXPLAYERS+1];
 int gI_LastStopInfo[MAXPLAYERS+1];
+int gI_LastGroundLandTick[MAXPLAYERS+1];
+float gF_ZoneStartSpeedLimit[MAXPLAYERS+1];
 
 // cookies
 Handle gH_HideCookie = null;
@@ -266,7 +268,7 @@ public void OnPluginStart()
 
 	// cvars and stuff
 	gCV_GodMode = new Convar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.\n4 - Prevent fall/world/entity damage (all except damage from other players).", 0, true, 0.0, true, 4.0);
-	gCV_PreSpeed = new Convar("shavit_misc_prespeed", "2", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.\n5 - Limit horizontal speed to prestrafe but allow prespeeding.", 0, true, 0.0, true, 5.0);
+	gCV_PreSpeed = new Convar("shavit_misc_prespeed", "2", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.\n5 - Limit horizontal speed to prestrafe but allow prespeeding. \n6 - Limit horizontal speed to prestrafe and block bunnyhopping.", 0, true, 0.0, true, 5.0);
 	gCV_HideTeamChanges = new Convar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = new Convar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnRestart = new Convar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if they use the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -1349,7 +1351,14 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			prespeed_type = gCV_PreSpeed.IntValue;
 		}
 
+		int tickCount = GetGameTickCount();
 		int iPrevGroundEntity = (gI_GroundEntity[client] != -1) ? EntRefToEntIndex(gI_GroundEntity[client]) : -1;
+
+		if (iPrevGroundEntity == -1 && iGroundEntity != -1)
+		{
+			gI_LastGroundLandTick[client] = tickCount;
+		}
+
 		if ((prespeed_type == 2 || prespeed_type == 3) && iPrevGroundEntity == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
 		{
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
@@ -1360,10 +1369,44 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
+			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
+			float zoneLimit = gF_ZoneStartSpeedLimit[client];
+			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
+
+			if (zoneLimit > 0.0)
+			{
+				fLimit = zoneLimit;
+			}
+			else if (cfgLimit > 0.0)
+			{
+				fLimit = cfgLimit;
+			}
+			else if (fLimit > maxPrestrafe)
+			{
+				fLimit = maxPrestrafe;
+			}
 
 			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
 			if (prespeed_type < 4 && fSpeed[2] > 0.0)
+			{
+				fLimit /= 3.0;
+			}
+
+			int iOldButtons = GetEntProp(client, Prop_Data, "m_nOldButtons");
+			// TODO: somehow incorporate the autobhop style thingy or figure out a better way to do all of this lmao
+			int iAutoBhop = Shavit_GetStyleSettingBool(Shavit_GetBhopStyle(client), "autobhop");
+			bool isJumping = (buttons & IN_JUMP) > 0;
+			if (!iAutoBhop)
+			{
+				isJumping = isJumping && (iOldButtons & IN_JUMP) == 0;
+			}
+			if (
+				   prespeed_type == 6
+			    && iGroundEntity != -1
+			    && tickCount - gI_LastGroundLandTick[client] <= 150
+			    && isJumping
+			)
 			{
 				fLimit /= 3.0;
 			}
@@ -1373,7 +1416,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 			if(fScale < 1.0)
 			{
-				if (prespeed_type == 5)
+				if (prespeed_type == 5 || prespeed_type == 6)
 				{
 					float zSpeed = fSpeed[2];
 					fSpeed[2] = 0.0;
@@ -1428,6 +1471,14 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 	return Plugin_Continue;
 }
 
+public void Shavit_OnEnterZone(int client, int type, int track, int id, int entity, int data)
+{
+	if (type == Zone_Start && track == Shavit_GetClientTrack(client))
+	{
+		gF_ZoneStartSpeedLimit[client] = float(data);
+	}
+}
+
 public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_SetTransmit, OnSetTransmit);
@@ -1439,6 +1490,7 @@ public void OnClientPutInServer(int client)
 
 	gI_LastWeaponTick[client] = 0;
 	gI_LastNoclipTick[client] = 0;
+	gI_LastGroundLandTick[client] = 0;
 
 	if(IsFakeClient(client))
 	{
@@ -2290,8 +2342,22 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
+			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
+			float zoneLimit = gF_ZoneStartSpeedLimit[client];
 			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
-			if (fLimit > maxPrestrafe) fLimit = maxPrestrafe;
+
+			if (zoneLimit > 0.0)
+			{
+				fLimit = zoneLimit;
+			}
+			else if (cfgLimit > 0.0)
+			{
+				fLimit = cfgLimit;
+			}
+			else if (fLimit > maxPrestrafe)
+			{
+				fLimit = maxPrestrafe;
+			}
 
 			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
@@ -2305,7 +2371,7 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 
 			if(fScale < 1.0)
 			{
-				if (prespeed_type == 5)
+				if (prespeed_type == 5 || prespeed_type == 6)
 				{
 					float zSpeed = fSpeed[2];
 					fSpeed[2] = 0.0;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -4406,7 +4406,20 @@ void CreateEditMenu(int client, bool autostage=false)
 	FormatEx(sMenuItem, 64, "%T", "ZoneForceRender", client, ((gA_EditCache[client].iFlags & ZF_ForceRender) > 0)? "＋":"－");
 	menu.AddItem("forcerender", sMenuItem);
 
-	if (gA_EditCache[client].iType == Zone_Stage)
+	if (gA_EditCache[client].iType == Zone_Start)
+	{
+		if (gA_EditCache[client].iData == 0)
+		{
+			FormatEx(sMenuItem, 64, "%T", "ZoneSetSpeedLimitDefault", client, gA_EditCache[client].iData);
+		}
+		else
+		{
+			FormatEx(sMenuItem, 64, "%T", "ZoneSetSpeedLimit", client, gA_EditCache[client].iData);
+		}
+
+		menu.AddItem("datafromchat", sMenuItem);
+	}
+	else if (gA_EditCache[client].iType == Zone_Stage)
 	{
 		if (autostage)
 		{

--- a/addons/sourcemod/translations/shavit-zones.phrases.txt
+++ b/addons/sourcemod/translations/shavit-zones.phrases.txt
@@ -260,6 +260,11 @@
 		"#format"	"{1:d}"
 		"en"		"Custom speed limit: {1} (No Limit)"
 	}
+	"ZoneSetSpeedLimitDefault"
+	{
+		"#format"	"{1:d}"
+		"en"		"Custom speed limit: {1} (Default Speedcap)"
+	}
 	"ZoneSetStage"
 	{
 		"#format"	"{1:d}"


### PR DESCRIPTION
* Add config flag for MaxPrestrafe override

* Allow zoners to edit startzone data

* Use start zone data field for prestrafe limit

* Add prespeed type 6 that behaves like 5 and prevents prehopping

* Fix formatting

* Bodged up code for 1 second prehop cooldown on prestrafe mode 6

* Make anti prespeed a little bit better (maybe????)

* Tiredly twiddle with prespeed style 6 impl

* Add description to maxprestrafe style-setting

* nitpicky styling things

* Use GetGameTickCount instead of GetSysTickCount

* ;

---------