### PR TITLE
add player PB to !style menu (#1239)

### DIFF
--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1405,7 +1405,19 @@ public Action Command_Style(int client, int args)
 
 				char sName[64];
 				GetStyleSetting(iStyle, "name", sName, sizeof(sName));
-				FormatEx(sDisplay, 64, "%s - %s: %s", sName, sWR, sTime);
+
+				float pb = Shavit_GetClientPB(client, iStyle, gA_Timers[client].iTimerTrack);
+
+				if(pb > 0.0)
+				{
+					char sPb[32];
+					FormatSeconds(pb, sPb, 32, false);
+					FormatEx(sDisplay, 64, "%s - %s: %s - PB: %s", sName, sWR, sTime, sPb);
+				}
+				else
+				{
+					FormatEx(sDisplay, 64, "%s - %s: %s", sName, sWR, sTime);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
* shavit-core.sp - add player pb to style menu

helps to see if you've already beaten a map on a style without changing to it first

* shavit-core.sp - move pb to only after a wr is found

* shavit-core.sp - fix whitespace